### PR TITLE
Added elseif functionality

### DIFF
--- a/wp-conditional-content/classes/class-core.php
+++ b/wp-conditional-content/classes/class-core.php
@@ -6,36 +6,248 @@
 class WP_Conditional_Content {
 
 	/**
-	 * Constructor functions, registers the 'conditional' shortcode
+	 * The state if an 'if' shortcode has been registered
+	 * @var		bool
+	 */
+	private $shortcode_init;
+
+	/**
+	 * The currently registered conditional statements
+	 * @var 	array
+	 */
+	private $if_statement_collection;
+
+	/**
+	 * Default values for a new conditional statement
+	 * @var 	array
+	 */
+	private $initial_statement_conditions;
+
+	/**
+	 * Constructor functions, registers the 'conditional' shortcodes
 	 *
 	 */
 	public function __construct() {
+
+		$this->shortcode_init = false;
+		$this->if_statement_collection = array();
+		$this->initial_statement_conditions = array( true, false, false, false );
 
 		# Base layer
 		add_shortcode( 'if', array( &$this, 'short_code_if' ) );
 
 		# Second layer
-		add_shortcode( 'if2', array( &$this, 'short_code_if' ) );
+		add_shortcode( 'if2', array( &$this, 'short_code_if_2' ) );
 
 		# Third layer
-		add_shortcode( 'if3', array( &$this, 'short_code_if' ) );
+		add_shortcode( 'if3', array( &$this, 'short_code_if_3' ) );
 
 		# Fourth layer
-		add_shortcode( 'if4', array( &$this, 'short_code_if' ) );
+		add_shortcode( 'if4', array( &$this, 'short_code_if_4' ) );
+
+		# Base layer elseif
+		add_shortcode( 'elseif', array( &$this, 'short_code_elseif' ));
+
+		# Second layer elseif
+		add_shortcode( 'elseif2', array( &$this, 'short_code_elseif_2' ));
+
+		# Third layer elseif
+		add_shortcode( 'elseif3', array( &$this, 'short_code_elseif_3' ));
+
+		# Fourth layer elseif
+		add_shortcode( 'elseif4', array( &$this, 'short_code_elseif_4' ));
 
 	}
 
 	/**
-	 * The function that is called by when the shortcode is parsed
+	 * The function that is called when the first if shortcode hook is fired; on 
+	 * first run initializes the statements collection array
 	 * @param array $atts The attributes of the shortcode
 	 * @param string $content The content between the shortcode tags
-	 * @return string If conditions are met $content, otherwise nothing.
+	 * @return string If conditions are met $content, otherwise false or nothing.
 	 * 
 	 */
 	public function short_code_if( $atts, $content ) {
 
+		if ( ! $this->shortcode_init )
+			$this->shortcode_init = true;
+
+		$this->if_statement_collection[] = $this->initial_statement_conditions;
+
 		if ( empty( $atts ) )
 			return $content;
+
+		return $this->parse_shortcode_if( $atts, $content );
+
+	}
+
+	/**
+	 * The function that is called when the second child if shortcode hook is 
+	 * fired
+	 * @param array $atts The attributes of the shortcode
+	 * @param string $content The content between the shortcode tags
+	 * @return string If conditions are met $content, otherwise false or nothing.
+	 * 
+	 */
+	public function short_code_if_2( $atts, $content ) {
+		return $this->shortcode_if_child( 1, $atts, $content );
+	}
+
+	/**
+	 * The function that is called when the third child if shortcode hook is 
+	 * fired
+	 * @param array $atts The attributes of the shortcode
+	 * @param string $content The content between the shortcode tags
+	 * @return string If conditions are met $content, otherwise false or nothing.
+	 * 
+	 */
+	public function short_code_if_3( $atts, $content ) {
+		return $this->shortcode_if_child( 2, $atts, $content );
+	}
+
+	/**
+	 * The function that is called when the fourth child if shortcode hook is 
+	 * fired
+	 * @param array $atts The attributes of the shortcode
+	 * @param string $content The content between the shortcode tags
+	 * @return string If conditions are met $content, otherwise false or nothing.
+	 * 
+	 */
+	public function short_code_if_4( $atts, $content ) {
+		return $this->shortcode_if_child( 3, $atts, $content );
+	}
+
+	/**
+	 * The function that is called when the first elseif shortcode hook is 
+	 * fired
+	 * @param array $atts The attributes of the shortcode
+	 * @param string $content The content between the shortcode tags
+	 * @return string If conditions are met $content, otherwise false or nothing.
+	 * 
+	 */
+	public function short_code_elseif( $atts, $content ) {
+		return $this->parse_shortcode_elseif( 0, $atts, $content );
+	}
+
+	/**
+	 * The function that is called when the second elseif shortcode hook is 
+	 * fired
+	 * @param array $atts The attributes of the shortcode
+	 * @param string $content The content between the shortcode tags
+	 * @return string If conditions are met $content, otherwise false or nothing.
+	 * 
+	 */
+	public function short_code_elseif_2( $atts, $content ) {
+		return $this->parse_shortcode_elseif( 1, $atts, $content );
+	}
+
+	/**
+	 * The function that is called when the third elseif shortcode hook is 
+	 * fired
+	 * @param array $atts The attributes of the shortcode
+	 * @param string $content The content between the shortcode tags
+	 * @return string If conditions are met $content, otherwise false or nothing.
+	 * 
+	 */
+	public function short_code_elseif_3( $atts, $content ) {
+		return $this->parse_shortcode_elseif( 2, $atts, $content );
+	}
+
+	/**
+	 * The function that is called when the fourth elseif shortcode hook is 
+	 * fired
+	 * @param array $atts The attributes of the shortcode
+	 * @param string $content The content between the shortcode tags
+	 * @return string If conditions are met $content, otherwise false or nothing.
+	 * 
+	 */
+	public function short_code_elseif_4( $atts, $content ) {
+		return $this->parse_shortcode_elseif( 3, $atts, $content );
+	}
+
+	/**
+	 * The function that handles the registering of child if shortcodes and 
+	 * adds it to the relevant conditional collection.
+	 * @param  int $instance The nested instance of the statement
+	 * @param  array $atts The attributes of the shortcode
+	 * @param  string $content The content between the shortcode tags
+	 * @return If parent if statement doesn't exist false, otherwise if conditions
+	 * are met $content or nothing.
+	 */
+	private function shortcode_if_child( $instance, $atts, $content ) {
+
+		if ( ! $this->shortcode_init )
+			return false;
+
+		// Gets the current instance of the parent conditional statement
+		$parent_condition_instance = count( $this->if_statement_collection ) - 1;
+		$this->if_statement_collection[ $parent_condition_instance ][ $instance ] = true;
+
+		if ( empty( $atts ) )
+			return $content;
+
+		return $this->parse_shortcode_if( $atts, $content );
+
+	}
+
+	/**
+	 * The function that is called to handle the shortcode attribute parsing
+	 * @param array $atts The attributes of the shortcode
+	 * @param string $content The content between the shortcode tags
+	 * @return string If conditions are met $content, otherwise false or nothing.
+	 * 
+	 */
+	private function parse_shortcode_if( $atts, $content ) {
+
+		/*
+		 * Check if the condition is met
+		 */
+		if ( ! $this->parse_shortcode_attributes( $atts ) ) {
+			return '';
+		}
+
+		return do_shortcode( $content );
+
+	}
+
+	/**
+	 * The function that handles the registering of elseif shortcodes and 
+	 * adds it to the relevant conditional collection.
+	 * @param  int $instance The nested instance of the statement
+	 * @param  array $atts The attributes of the shortcode
+	 * @param  string $content The content between the shortcode tags
+	 * @return If parent if statement doesn't exist false, otherwise if conditions
+	 * are met $content or nothing.
+	 */
+	private function parse_shortcode_elseif( $instance, $atts, $content ) {
+
+		if ( ! $this->shortcode_init )
+			return false;
+
+		// Gets the current instance of the parent conditional statement
+		$parent_condition_instance = count( $this->if_statement_collection ) - 1;
+		$this->if_statement_collection[ $parent_condition_instance ][ $instance ] = true;
+
+		if ( empty( $atts ) || ! $this->if_statement_collection[ $parent_condition_instance ][ $instance ] )
+			return $content;
+
+		/*
+		 * Check if the condition is met
+		 */
+		if ( ! $this->parse_shortcode_attributes( $atts ) ) {
+			return '';
+		}
+
+		return do_shortcode( $content );
+		
+	}
+
+	/**
+	 * Parses the shortcode attributes and returns the relevant state
+	 * @param  array $atts The attributes of the shortcode
+	 * @return $condition_met The returned state of the shortcode attributes
+	 */
+	private function parse_shortcode_attributes( $atts ) {
 
 		$condition_met = false;
 
@@ -43,24 +255,22 @@ class WP_Conditional_Content {
 
 		if ( isset( $atts['match'] ) )
 			$match = ( 'contain' == $atts['match'] ) ? 'contain' : 'exact';
-		
+
 		foreach ( $atts as $key => $value ) {
 
-			if ( 'qs' == $key )
+			if ( 'qs' == $key ) {
 				$condition_met = $this->condition_query_string( $value, $match );
-			
-			elseif ( 'referrer' == $key )
+			} elseif ( 'referrer' == $key ) {
 				$condition_met = $this->condition_referrer( $value, $match );
-
-			elseif ( 'role' == $key )
+			} elseif ( 'role' == $key ) {
 				$condition_met = $this->condition_user_role( $value );
-
-			if( ! $condition_met )
-				return '';
+			} else {
+				return false;
+			}
 
 		}
 
-		return do_shortcode( $content );
+		return $condition_met;
 
 	}
 
@@ -72,7 +282,7 @@ class WP_Conditional_Content {
 	 */
 	private function condition_query_string( $value, $match ) {
 
-		if( ! strstr( $value, ':' ) )
+		if ( ! strstr( $value, ':' ) )
 			return false;
 		
 		list( $qs_key, $qs_value ) = explode( ':', $value );


### PR DESCRIPTION
Added [elseif] functionality and collection of the current post's conditional statements to prevent improperly nested statements (i.e. no if2/if3 output if parent if does not exist). 

```
[if qs="product:shoe"]
  <h2>There's a snake in my boot!</h2>
  [if2 qs="color:red"]
    The color is red
  [/if2][elseif2 qs="color:rood"]
    De kleur is rood
  [/elseif2]
[/if]
[elseif qs="product:shoes"]
<h2>To infinity and beyond!</h2>
[/elseif]
```

If prior if statement is missing the elseif will not return output regardless of if the parameters are met.